### PR TITLE
Escaping invalid characters in note titles

### DIFF
--- a/app/src/main/assets/reader/reader/reader.html
+++ b/app/src/main/assets/reader/reader/reader.html
@@ -572,4 +572,4 @@ mdl-layout--fixed-header">
 	</span>
 
 </body>
-</head>
+</html>

--- a/app/src/main/java/com/spisoft/quicknote/browser/RenameDialog.java
+++ b/app/src/main/java/com/spisoft/quicknote/browser/RenameDialog.java
@@ -9,8 +9,10 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.spisoft.quicknote.R;
+import com.spisoft.quicknote.databases.NoteManager;
 
 /**
  * Created by phoenamandre on 14/02/16.
@@ -24,7 +26,9 @@ public class RenameDialog extends DialogFragment implements View.OnClickListener
     @Override
     public void onClick(View v) {
         if(mRenameListener.renameTo(mTextView.getText().toString()))
-            dismiss();
+                dismiss();
+        else if(!NoteManager.isNoteNameValid(mTextView.getText().toString()))
+            Toast.makeText(getActivity(), R.string.unable_to_rename_invalid_name, Toast.LENGTH_LONG).show();
 
     }
 

--- a/app/src/main/java/com/spisoft/quicknote/databases/NoteManager.java
+++ b/app/src/main/java/com/spisoft/quicknote/databases/NoteManager.java
@@ -50,6 +50,7 @@ public class NoteManager
     public static final String ACTION_UPDATE_END = "update_note_end";
     public static final int PREVIEW_WIDTH = 400;
     public static final int PREVIEW_HEIGHT = 400;
+    public static final char[] RESERVED_CHARS = "|\\?*<\":>+[]/'".toCharArray();
 
 
     public static void updateMetadata(final Context context, final Note note){
@@ -116,6 +117,9 @@ public class NoteManager
     }
 
     public static String moveNote(Context context,Note note, String to){
+        if(!isNoteNameValid(to.split("/notes/")[1]))
+            return null;
+
         File notFile = new File(note.path);
         File toFile = new File(to);
         Log.d(TAG,"renaming to "+to+" "+toFile.exists());
@@ -237,6 +241,14 @@ public class NoteManager
             }
         }
         return false;
+    }
+
+    public static boolean isNoteNameValid(String noteName) {
+        for(char c : RESERVED_CHARS)
+            if(noteName.indexOf(c) != -1)
+                return false;
+
+        return true;
     }
 
     public static String getDefaultHTML() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="allow">Allow</string>
     <string name="exit">Exit</string>
     <string name="unable_to_rename_use">Unable to rename a document while being used</string>
+    <string name="unable_to_rename_invalid_name">Note contains invalid characters</string>
     <string name="unable_to_delete_use">Unable to delete an opened document</string>
     <string name="add_screenshot">Add screenshot to note ?</string>
     <string name="please_wait_update">Please wait while your notes are being updated</string>


### PR DESCRIPTION
This pull request adds code to prevent the user from making or renaming a note with characters forbidden for file names (includes "/"). To allow notes to have "/"s in their names, we would need a new way of storing notes.

[Issue #70](https://github.com/PhieF/CarnetAndroid/issues/70)

Other Changes:
Corrected [the end html tag in reader.html](https://github.com/PhieF/CarnetAndroid/blob/master/app/src/main/assets/reader/reader/reader.html#L575)