### PR TITLE
Fixed the overlapped texts in the largest font and display size

### DIFF
--- a/app/src/main/res/layout/grid_note_layout.xml
+++ b/app/src/main/res/layout/grid_note_layout.xml
@@ -100,6 +100,8 @@
                     android:text="Small Text"
                     android:id="@+id/date_tv"
                     android:alpha="0.5"
+                    android:textSize="14dp"
+                    android:layout_alignParentLeft="true"
                     android:paddingTop="5dp"
                     android:layout_below="@id/display_more"
                     android:textColor="?attr/MainNoteTextColor"
@@ -109,11 +111,14 @@
                     android:id="@+id/mark_tv"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_toLeftOf="@id/optionsButton"
-                    android:textColor="?attr/MainNoteTextColor"
-                    android:text="Small Tfdfext"
                     android:layout_above="@id/keywords"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:textSize="14dp"
+                    android:layout_toLeftOf="@id/optionsButton"
+                    android:text="Small Tfdfext"
+                    android:layout_alignParentRight="true"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?attr/MainNoteTextColor" />
+
                 <com.google.android.flexbox.FlexboxLayout
                     android:id="@+id/keywords"
                     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/instance_item.xml
+++ b/app/src/main/res/layout/instance_item.xml
@@ -58,19 +58,22 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textSize="14dp"
                 android:text="Small Text"
                 android:id="@+id/register_tv"
                 android:layout_below="@id/description_tv"
+                android:layout_toStartOf="@+id/reliability_tv"
+                android:layout_alignParentLeft="true"
                 android:layout_gravity="bottom" />
 
             <TextView
                 android:id="@+id/reliability_tv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:text="Small Tfdfext"
                 android:layout_below="@id/description_tv"
+                android:layout_alignParentRight="true"
+                android:textSize="14dp"
+                android:text="Small Tfdfext"
                 android:textAppearance="?android:attr/textAppearanceSmall" />
 
         </RelativeLayout>


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #134, and I have fixed the overlapped texts in the largest font and display size. I would appreciate it if you could kindly revise my code and leave me some suggestions. Thank you so much for your precious time!

Here are screenshots after my modifications, as you can see that those overlapped texts are fully separated now :)

<img src="https://user-images.githubusercontent.com/25502419/129676231-fce1a8c5-255a-4f45-bfb9-2281a4ef2723.png" alt="copy" width="250"/> <img src="https://user-images.githubusercontent.com/25502419/129676235-c7f2a1f1-231e-40ff-b27f-d807de10ee96.png" alt="copy" width="250"/>

